### PR TITLE
[Feat] Add details for Alpaca listOperations and getBlock

### DIFF
--- a/.changeset/quick-jars-peel.md
+++ b/.changeset/quick-jars-peel.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": minor
+---
+
+Add details for Alpaca listOperations and getBlock in undelegate flow

--- a/libs/coin-modules/coin-sui/src/bridge/formatters.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/formatters.ts
@@ -1,21 +1,25 @@
+import { BigNumber } from "bignumber.js";
 import { OperationExtra, OperationExtraRaw } from "@ledgerhq/types-live";
 import type { SuiOperationExtra, SuiOperationExtraRaw } from "../types";
 
-export function fromOperationExtraRaw(extraRaw: OperationExtraRaw) {
-  if (extraRaw) {
-    // reserved for future use
-  }
-
+export function fromOperationExtraRaw(extraRaw: OperationExtraRaw): SuiOperationExtra {
   const extra: SuiOperationExtra = {};
+  if (!extraRaw) return extra;
+  const raw = extraRaw as SuiOperationExtraRaw;
+
+  if (raw.coinType) extra.coinType = raw.coinType;
+  if (raw.transferAmount) extra.transferAmount = new BigNumber(raw.transferAmount);
 
   return extra;
 }
 
-export function toOperationExtraRaw(extra: OperationExtra) {
-  if (extra) {
-    // reserved for future use
-  }
+export function toOperationExtraRaw(extra: OperationExtra): SuiOperationExtraRaw {
   const extraRaw: SuiOperationExtraRaw = {};
+  if (!extra) return extraRaw;
+  const typed = extra as SuiOperationExtra;
+
+  if (typed.coinType) extraRaw.coinType = typed.coinType;
+  if (typed.transferAmount) extraRaw.transferAmount = typed.transferAmount.toString();
 
   return extraRaw;
 }

--- a/libs/coin-modules/coin-sui/src/network/sdk.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.integration.test.ts
@@ -11,6 +11,7 @@ import {
   getBlock,
   getBlockInfo,
   getStakes,
+  getListOperations,
 } from "./sdk";
 import { getEnv } from "@ledgerhq/live-env";
 
@@ -238,6 +239,46 @@ describe("SUI SDK Integration tests", () => {
         expect(stake.amount).toEqual(stake.amountDeposited + stake.amountRewarded);
         expect(stake.details).toBeDefined();
       });
+    });
+  });
+
+  describe("DELEGATE/UNDELEGATE", () => {
+    const accountWithStaking = "0xea438b6ce07762ea61e04af4d405dfcf197d5f77d30765f365f75460380f3cce";
+
+    test("listOperations UNDELEGATE should have details from UnstakingRequestEvent", async () => {
+      const result = await getListOperations(accountWithStaking, "desc");
+      const undelegateOps = result.items.filter(op => op.type === "UNDELEGATE");
+
+      expect(undelegateOps.length).toBeGreaterThan(0);
+
+      undelegateOps.forEach(op => {
+        expect(op.details).toBeDefined();
+        expect(op.details?.validatorAddress).toMatch(/^0x[0-9a-f]+$/);
+        expect(typeof op.details?.principalAmount).toBe("bigint");
+        expect(typeof op.details?.rewardAmount).toBe("bigint");
+      });
+    });
+
+    test("getBlock UNDELEGATE should have details from UnstakingRequestEvent", async () => {
+      const result = await getListOperations(accountWithStaking, "desc");
+      const undelegateOp = result.items.find(op => op.type === "UNDELEGATE");
+      expect(undelegateOp).toBeDefined();
+
+      const checkpointId = undelegateOp!.tx.block.height.toString();
+      const block = await getBlock(checkpointId);
+
+      const undelegateTx = block.transactions.find(
+        tx => tx.operations.some(op => op.type === "other" && op.operationType === "UNDELEGATE"),
+      );
+      expect(undelegateTx).toBeDefined();
+
+      const undelegateBlockOp = undelegateTx!.operations.find(
+        op => op.type === "other" && op.operationType === "UNDELEGATE",
+      ) as Record<string, unknown>;
+      expect(undelegateBlockOp).toBeDefined();
+      expect(undelegateBlockOp.validatorAddress).toMatch(/^0x[0-9a-f]+$/);
+      expect(typeof undelegateBlockOp.principalAmount).toBe("bigint");
+      expect(typeof undelegateBlockOp.rewardAmount).toBe("bigint");
     });
   });
 });

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -396,20 +396,30 @@ export const alpacaGetOperationAmount = (
   }
 };
 
-function getUnstakingDetails(transaction: SuiTransactionBlockResponse): Record<string, unknown> {
-  const details: Record<string, unknown> = {};
+type UnstakingRequestEventJson = {
+  validator_address: string;
+  principal_amount: string;
+  reward_amount: string;
+};
 
+type UnstakingDetails = {
+  validatorAddress?: string;
+  principalAmount?: bigint;
+  rewardAmount?: bigint;
+};
+
+function getUnstakingDetails(transaction: SuiTransactionBlockResponse): UnstakingDetails {
   const unstakingEvent = transaction.events?.find(
     e => e.type === "0x3::validator::UnstakingRequestEvent",
   );
-  if (unstakingEvent?.parsedJson) {
-    const parsed = unstakingEvent.parsedJson as Record<string, string>;
-    details.validatorAddress = parsed.validator_address;
-    details.principalAmount = BigInt(parsed.principal_amount || "0");
-    details.rewardAmount = BigInt(parsed.reward_amount || "0");
-  }
+  if (!unstakingEvent?.parsedJson) return {};
 
-  return details;
+  const parsed = unstakingEvent.parsedJson as UnstakingRequestEventJson;
+  return {
+    validatorAddress: parsed.validator_address,
+    principalAmount: BigInt(parsed.principal_amount || "0"),
+    rewardAmount: BigInt(parsed.reward_amount || "0"),
+  };
 }
 
 /**

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -62,6 +62,7 @@ const TRANSACTIONS_QUERY_OPTIONS: SuiTransactionBlockResponseOptions = {
   showInput: true,
   showBalanceChanges: true,
   showEffects: true, // To get transaction status and gas fee details
+  showEvents: true, // Required to extract staking/unstaking details from events
 };
 
 type GenericInput<T> = T extends (...args: infer K) => unknown ? K : never;
@@ -395,6 +396,22 @@ export const alpacaGetOperationAmount = (
   }
 };
 
+function getUnstakingDetails(transaction: SuiTransactionBlockResponse): Record<string, unknown> {
+  const details: Record<string, unknown> = {};
+
+  const unstakingEvent = transaction.events?.find(
+    e => e.type === "0x3::validator::UnstakingRequestEvent",
+  );
+  if (unstakingEvent?.parsedJson) {
+    const parsed = unstakingEvent.parsedJson as Record<string, string>;
+    details.validatorAddress = parsed.validator_address;
+    details.principalAmount = BigInt(parsed.principal_amount || "0");
+    details.rewardAmount = BigInt(parsed.reward_amount || "0");
+  }
+
+  return details;
+}
+
 /**
  * This function is only used by alpaca code path
  *
@@ -425,6 +442,7 @@ export function alpacaTransactionToOp(
     senders: getOperationSenders(transaction.transaction?.data),
     type,
     value: BigInt(alpacaGetOperationAmount(address, transaction, coinType).toString()),
+    details: getUnstakingDetails(transaction),
   };
 }
 
@@ -529,6 +547,7 @@ export function toBlockOperation(
           address: change.owner.AddressOwner,
           asset: toSuiAsset(change.coinType),
           amount: BigInt(removeFeesFromAmountForNative(change, fees).toString()),
+          ...getUnstakingDetails(transaction),
         },
       ];
     default:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
